### PR TITLE
Fix api/v2/trades parameter

### DIFF
--- a/source/includes/_restful-market.md
+++ b/source/includes/_restful-market.md
@@ -31,7 +31,7 @@
 
 **HTTP Request**
 
-`GET api/v2/trades/symbol=<symbol>&n=<n>`
+`GET api/v2/trades?symbol=<symbol>&n=<n>`
 
 **Parameters**
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
I sent a request to the address of the listed API, but I couldn't connect, so I checked the address of the v1 API.

As a result, the URL was incorrect and corrected.